### PR TITLE
初始化时将文件设置为时间降序排列

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ const (
 	getinfoURL    = "https://uplb.115.com/3.0/getuploadinfo.php"
 	listFileURL   = "https://webapi.115.com/files?aid=1&cid=%d&o=user_ptime&asc=0&offset=0&show_dir=0&limit=%d&natsort=1&format=json"
 	downloadURL   = "https://proapi.115.com/app/chrome/downurl"
+	orderURL      = "https://webapi.115.com/files/order"
 	appVer        = "26.2.2"
 	userAgent     = "Mozilla/5.0 115disk/" + appVer
 	endString     = "000000"
@@ -371,6 +372,16 @@ func initialize() (e error) {
 
 	err := getUserKey()
 	checkErr(err)
+
+	// 将cid对应文件夹设置为时间降序
+	orderBody := fmt.Sprintf("user_order=user_ptime&file_id=%d&user_asc=0&fc_mix=0", config.CID)
+	v, err := postFormJSON(orderURL, orderBody)
+	checkErr(err)
+	if !v.GetBool("state") {
+		panic(fmt.Sprintf("排序文件夹 %d 出现错误：%v", config.CID, v.GetStringBytes("error")))
+	} else if *verbose {
+		log.Printf("排序文件夹 %d 成功", config.CID)
+	}
 
 	return nil
 }

--- a/oss.go
+++ b/oss.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -60,6 +61,31 @@ func getURLJSON(url string) (v *fastjson.Value, e error) {
 
 	body, err := getURL(url)
 	checkErr(err)
+	var p fastjson.Parser
+	v, err = p.ParseBytes(body)
+	checkErr(err)
+	return v, nil
+}
+
+// 获取POST表单请求响应的json
+func postFormJSON(url string, formStr string) (v *fastjson.Value, e error) {
+	defer func() {
+		if err := recover(); err != nil {
+			e = fmt.Errorf("postURL() error: %w", err)
+		}
+	}()
+
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer([]byte(formStr)))
+	checkErr(err)
+	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("Cookie", config.Cookies)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := httpClient.Do(req)
+	checkErr(err)
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	checkErr(err)
+
 	var p fastjson.Parser
 	v, err = p.ParseBytes(body)
 	checkErr(err)


### PR DESCRIPTION
115可能在这段时间修改了API，如果 cid 对应的文件夹是以其他顺序排列的（例如文件名），访问 listFileURL 这个 API 的时候就会报错：

```json
{"count":18,"order":"file_name","is_asc":1,"fc_mix":0,"state":false,"error":"","errNo":20130827}
```

经过一些试验我发现可以通过先把这个目录按照时间降序排列一下，结果就会正常。从浏览器抓到的排序 API 是：

```
curl 'https://webapi.115.com/files/order' \
-X 'POST' \
-H 'Content-Type: application/x-www-form-urlencoded' \
...
--data 'user_order=user_ptime&file_id=<cid>&user_asc=0&fc_mix=0'
```

因此我建议将这个排序的处理放到程序的初始化部分，以避免产生上述问题。