### PR TITLE
将上传结果中 failed 字段从 string 改为包含 path 和 cid 的结构体

### DIFF
--- a/main.go
+++ b/main.go
@@ -85,11 +85,17 @@ type uploadConfig struct {
 	PartsNum  uint   `json:"partsNum"`  // 断点续传的分片数量
 }
 
+// 上传失败的文件信息
+type failedFile struct {
+	Path string `json:"path"` // 上传文件的路径
+	CID  uint64 `json:"cid"`  // 上传文件的 115 父文件夹 cid
+}
+
 // 上传结果数据
 type resultData struct {
-	Success []string `json:"success"` // 上传成功的文件
-	Failed  []string `json:"failed"`  // 上传失败的文件
-	Saved   []string `json:"saved"`   // 保存上传进度的文件
+	Success []string     `json:"success"` // 上传成功的文件
+	Failed  []failedFile `json:"failed"`  // 上传失败的文件
+	Saved   []string     `json:"saved"`   // 保存上传进度的文件
 }
 
 // 要上传的文件的信息
@@ -216,8 +222,8 @@ func exitPrint() {
 		fmt.Println(s)
 	}
 	fmt.Printf("上传失败的文件（%d）：\n", len(result.Failed))
-	for _, s := range result.Failed {
-		fmt.Println(s)
+	for _, f := range result.Failed {
+		fmt.Printf("  文件：%s，cid：%d\n", f.Path, f.CID)
 	}
 	fmt.Printf("保存上传进度的文件（%d）：\n", len(result.Saved))
 	for _, s := range result.Saved {
@@ -703,7 +709,7 @@ func (file *fileInfo) uploadFile() {
 		_, err := file.fastUploadFile()
 		if err != nil {
 			log.Printf("秒传模式上传 %s 出现错误：%v", file.Path, err)
-			result.Failed = append(result.Failed, file.Path)
+			result.Failed = append(result.Failed, failedFile{Path: file.Path, CID: file.ParentID})
 			return
 		}
 		result.Success = append(result.Success, file.Path)
@@ -715,7 +721,7 @@ func (file *fileInfo) uploadFile() {
 			err := ossUploadFile(token, file.Path)
 			if err != nil {
 				log.Printf("普通模式上传 %s 出现错误：%v", file.Path, err)
-				result.Failed = append(result.Failed, file.Path)
+				result.Failed = append(result.Failed, failedFile{Path: file.Path, CID: file.ParentID})
 				return
 			}
 		}
@@ -735,7 +741,7 @@ func (file *fileInfo) uploadFile() {
 						return
 					}
 					log.Printf("断点续传模式上传 %s 出现错误：%v", file.Path, err)
-					result.Failed = append(result.Failed, file.Path)
+					result.Failed = append(result.Failed, failedFile{Path: file.Path, CID: file.ParentID})
 					return
 				}
 			}
@@ -743,7 +749,7 @@ func (file *fileInfo) uploadFile() {
 		} else {
 			if info.IsDir() {
 				log.Printf("%s 不能是文件夹", saveFile)
-				result.Failed = append(result.Failed, file.Path)
+				result.Failed = append(result.Failed, failedFile{Path: file.Path, CID: file.ParentID})
 				return
 			}
 			log.Printf("发现文件 %s 的上传曾经中断过，现在开始断点续传", file.Path)
@@ -753,7 +759,7 @@ func (file *fileInfo) uploadFile() {
 					return
 				}
 				log.Printf("断点续传模式上传 %s 出现错误：%v", file.Path, err)
-				result.Failed = append(result.Failed, file.Path)
+				result.Failed = append(result.Failed, failedFile{Path: file.Path, CID: file.ParentID})
 				return
 			}
 			result.Success = append(result.Success, file.Path)


### PR DESCRIPTION
## 改动说明

将上传结果 `resultData` 中的 `Failed` 字段从 `[]string` 改为 `[]failedFile` 结构体。

### 修改前

```json
{
  "failed": ["/path/to/file1", "/path/to/file2"]
}
```

### 修改后

```json
{
  "failed": [
    {"path": "/path/to/file1", "cid": 12345},
    {"path": "/path/to/file2", "cid": 67890}
  ]
}
```

### 变更内容

- 新增 `failedFile` 结构体，包含 `path`（上传文件路径）和 `cid`（115 父文件夹 cid）两个字段
- 将 `resultData.Failed` 类型从 `[]string` 改为 `[]failedFile`
- 更新所有 `result.Failed` 的 append 调用（共 5 处），同时记录文件路径和父 cid
- 更新 `exitPrint()` 中打印失败文件信息的格式，展示文件路径和 cid

### 动机

当配置了 `-r` 参数将上传结果保存到指定文件夹时，原来的 `failed` 字段仅记录文件路径字符串，丢失了上传目标文件夹信息。改为结构体后，可以同时知道：
1. 哪个文件上传失败了（`path`）
2. 该文件原本要上传到哪个 115 文件夹（`cid`）

这对于后续重试上传失败的文件时非常有用，可以直接使用 `-c cid` 参数重新上传到正确的文件夹。

⚠️ **注意：这是一个破坏性变更**，`failed` 字段的 JSON 格式从字符串数组变为对象数组，依赖此 JSON 结构的下游脚本需要相应调整。


Made with [Cursor](https://cursor.com)